### PR TITLE
Optimize CSS: Hide horizontal scollbars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+body {
+  overflow-x: hidden;
+}
+
 .transition-fade {
   opacity: 1;
   transition: 500ms;


### PR DESCRIPTION
Add `body { overflow-x: hidden; }` to hide the horizontal scrollbars that appear during active transitioning.